### PR TITLE
Add missing chest in Eastern Vault and remove trailing comma

### DIFF
--- a/locations.json
+++ b/locations.json
@@ -3916,7 +3916,7 @@
 								"sections": [
 									{
 										"name": "It's a Secret to Nobody",
-										"item_count": 1
+										"item_count": 2
 									}
 								]
 							},
@@ -4894,7 +4894,7 @@
 									{
 										"name": "Show him the Far Shores",
 										"hosted_item": "librarian",
-										"access_rules": ["ring","lure,[glitches]"],
+										"access_rules": ["ring","lure,[glitches]"]
 									},
 									{
 										"name": "Stolen to the Top of the Sky",


### PR DESCRIPTION
1. The Westmost Upper Room in Eastern Vault has 2 chests, not 1.
2. There is a trailing `,` in one of the sections which errors in a pure JSON parser.

![image](https://github.com/SapphireSapphic/TunicTracker/assets/130935387/17c464ea-c81a-46dd-99f8-405e3b0b2862)
