### PR TITLE
Fix ladder shuffle off from AP

### DIFF
--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -225,6 +225,8 @@ function onClear(slot_data)
 
     if slot_data.shuffle_ladders then
         Tracker:FindObjectForCode("ladder_shuffle_off").CurrentStage = slot_data.shuffle_ladders
+        -- needs to be called because onClear turns all the ladders off and the above line doesn't reenable them if shuffle_ladders is 0
+        ladderLayoutChange()
     end
     
     -- manually run snes interface functions after onClear in case we are already ingame


### PR DESCRIPTION
Connecting to an AP seed with `shuffle_ladders` set to off (0) does not behave correctly in 1.7.1.

Expected:
- Ladder shuffle setting remains off
- All ladders treated as collected

Actual:
- Ladder shuffle setting remains off
- **All ladders treated as uncollected**

This is because `onClear` resets the state of every item in `ITEM_MAPPING`, including ladders. Setting the stage of `ladder_shuffle_off` later does not trigger the watch on `ladder_shuffle_off` because its stage does not change (0 -> 0).

The fix is to manually call `ladderLayoutChange()` regardless of whether the stage change or not. This does result in the function being called multiple times if the state does change, but `ladderLayoutChange()` is idempotent and safe to call repeatedly.

Tested against AP seeds with ladder shuffle enabled and disabled and both resulted in the correct behaviour.