### PR TITLE
Move hints panels into options

### DIFF
--- a/items/common_pop_modified.json
+++ b/items/common_pop_modified.json
@@ -1,19 +1,26 @@
 [
-    {
-        "name": "Auto Tab Switching",
-        "type": "progressive",
-        "codes": "auto_tab",
-        "loop": true,
-        "allow_disabled": false,
-        "initial_stage_idx": 1,
-        "stages": [
-          {
-            "img": "images/cog_gray.png"
-          },
-          {
-            "img": "images/cog.png",
-            "codes": "auto_tab"
-          }
-        ]
+  {
+    "name": "Auto Tab Switching",
+    "type": "progressive",
+    "codes": "auto_tab",
+    "loop": true,
+    "allow_disabled": false,
+    "initial_stage_idx": 1,
+    "stages": [
+      {
+        "img": "images/cog_gray.png"
+      },
+      {
+        "img": "images/cog.png",
+        "codes": "auto_tab"
       }
+    ]
+  },
+  {
+    "name": "Show Hints",
+    "codes": "show_hints",
+    "loop": true,
+    "type": "toggle",
+    "img": "images/huh.png"
+  }
 ]

--- a/layouts/trackerpop_hints.json
+++ b/layouts/trackerpop_hints.json
@@ -1,83 +1,4 @@
 {
-  "settings_popup": {
-    "type": "array",
-    "margin": "5",
-    "content": [
-      {
-        "type": "group",
-        "header": "Glitch Mode",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "item",
-            "margin": "-5,-1,-5,-5",
-            "item": "mode"
-          }
-        ]
-      },
-      {
-        "type": "group",
-        "header": "Classic/Hexagon Quest",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "item",
-            "margin": "-5,-1,-5,-5",
-            "item": "hexagonquest"
-          }
-        ]
-      },
-      {
-        "type": "group",
-        "header": "Sword Setting",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "item",
-            "margin": "-5,-1,-5,-5",
-            "item": "progswordSetting"
-          }
-        ]
-      },
-      {
-        "type": "group",
-        "header": "Ladder Shuffle",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "item",
-            "margin": "-5,-1,-5,-5",
-            "item": "ladder_shuffle_off"
-          }
-        ]
-      },
-      {
-        "type": "group",
-        "header": "Pack Settings",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "array",
-            "orientation": "horizontal",
-            "content": [
-              {
-                "type": "item",
-                "max_width": 80,
-                "margin": "5,5,5,5",
-                "item": "auto_tab"
-              },
-              {
-                "type": "item",
-                "max_width": 80,
-                "margin": "5,5,5,5",
-                "item": "show_hints"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
   "tracker_horizontal": {
     "type": "container",
     "background": "#877373",
@@ -113,6 +34,26 @@
               "content": {
                 "type": "layout",
                 "key": "other"
+              }
+            },
+            {
+              "type": "group",
+              "header": "Hints",
+              "margin": "0,0,3,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "hints"
+              }
+            },
+            {
+              "type": "group",
+              "header": "More Hints",
+              "margin": "0,0,3,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "hints2"
               }
             }
           ]

--- a/layouts/trackerpop_ladders.json
+++ b/layouts/trackerpop_ladders.json
@@ -1,41 +1,41 @@
 {
-    "tracker_horizontal": {
-        "type": "container",
-        "background": "#877373",
-        "content": {
-            "type": "dock",
-            "dropshadow": true,
-            "content": [
-                {
-                    "type": "dock",
-                    "dock": "bottom",
-                    "content": [
-                        {
-                            "type": "group",
-                            "header": "Items",
-                            "margin": "0,0,3,0",
-                            "dock": "left",
-                            "content": {
-                                "type": "layout",
-                                "key": "shared_item_grid"
-                            },
-                            "header_content": {
-                                "type": "button_popup",
-                                "style": "settings",
-                                "popup_background": "#55212121",
-                                "layout": "settings_popup"
-                            }
-                        },
-						{
-							"type": "group",
-                            "header": "Other Treasures",
-                            "margin": "0,0,3,0",
-                            "dock": "left",
-                            "content": {
-                                "type": "layout",
-                                "key": "other"
-                            }
-						},
+  "tracker_horizontal": {
+    "type": "container",
+    "background": "#877373",
+    "content": {
+      "type": "dock",
+      "dropshadow": true,
+      "content": [
+        {
+          "type": "dock",
+          "dock": "bottom",
+          "content": [
+            {
+              "type": "group",
+              "header": "Items",
+              "margin": "0,0,3,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "shared_item_grid"
+              },
+              "header_content": {
+                "type": "button_popup",
+                "style": "settings",
+                "popup_background": "#55212121",
+                "layout": "settings_popup"
+              }
+            },
+            {
+              "type": "group",
+              "header": "Other Treasures",
+              "margin": "0,0,3,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "other"
+              }
+            },
             {
               "type": "group",
               "header": "Ladders",
@@ -45,154 +45,159 @@
                 "type": "layout",
                 "key": "ladders"
               }
+            }
+          ]
+        },
+        {
+          "type": "tabbed",
+          "tabs": [
+            {
+              "title": "Overworld",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "overworld"
+                ]
+              }
             },
-						{
-							"type": "group",
-                            "header": "Hints",
-                            "margin": "0,0,3,0",
-                            "dock": "left",
-                            "content": {
-                                "type": "layout",
-                                "key": "hints"
-                            }
-						},
-						{
-							"type": "group",
-                            "header": "More Hints",
-                            "margin": "0,0,3,0",
-                            "dock": "left",
-                            "content": {
-                                "type": "layout",
-                                "key": "hints2"
-                            }
-						}
-                    ]
-                },
-                {
-                    "type":"tabbed",
-					"tabs": [
-						//{							
-						//	"title": "Full Map",
-						//	"content": {
-						//		"type": "map",
-						//		"maps": ["fullmap"]
-						//	}
-						//},
-						{							
-							"title": "Overworld",
-							"content": {
-								"type": "map",
-								"maps": ["overworld"]
-							}
-						},
-						{							
-							"title": "East Forest",
-							"content": {
-								"type": "map",
-								"maps": ["east_forest"]
-							}
-						},
-						{							
-							"title": "Beneath the Well",
-							"content": {
-								"type": "map",
-								"maps": ["well"]
-							}
-						},
-						{							
-							"title": "Dark Tomb",
-							"content": {
-								"type": "map",
-								"maps": ["dark_tomb"]
-							}
-						},
-						{							
-							"title": "West Garden",
-							"content": {
-								"type": "map",
-								"maps": ["west_gardens"]
-							}
-						},
-						{							
-							"title": "Beneath the Earth",
-							"content": {
-								"type": "map",
-								"maps": ["earth"]
-							}
-						},
-						{							
-							"title": "Eastern Vault",
-							"content": {
-								"type": "map",
-								"maps": ["eastern_vault"]
-							}
-						},
-						{							
-							"title": "Ruined Atoll",
-							"content": {
-								"type": "map",
-								"maps": ["ruined_atoll"]
-							}
-						},
-						{							
-							"title": "Frog's Domain",
-							"content": {
-								"type": "map",
-								"maps": ["frogs_domain"]
-							}
-						},
-						{							
-							"title": "The Grand Library",
-							"content": {
-								"type": "map",
-								"maps": ["library"]
-							}
-						},
-						{							
-							"title": "The Quarry",
-							"content": {
-								"type": "map",
-								"maps": ["quarry"]
-							}
-						},
-						{							
-							"title": "The Rooted Ziggurat",
-							"content": {
-								"type": "map",
-								"maps": ["ziggurat"]
-							}
-						},
-						{							
-							"title": "Swamp",
-							"content": {
-								"type": "map",
-								"maps": ["graveyard"]
-							}
-						},
-						{							
-							"title": "The Cathedral",
-							"content": {
-								"type": "map",
-								"maps": ["cathedral"]
-							}
-						},
-						{							
-							"title": "The Far Shore",
-							"content": {
-								"type": "map",
-								"maps": ["far_shore"]
-							}
-						},
-						{							
-							"title": "HOLY CROSS",
-							"content": {
-								"type": "map",
-								"maps": ["secrets"]
-							}
-						}
-					]
-                }
-            ]
+            {
+              "title": "East Forest",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "east_forest"
+                ]
+              }
+            },
+            {
+              "title": "Beneath the Well",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "well"
+                ]
+              }
+            },
+            {
+              "title": "Dark Tomb",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "dark_tomb"
+                ]
+              }
+            },
+            {
+              "title": "West Garden",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "west_gardens"
+                ]
+              }
+            },
+            {
+              "title": "Beneath the Earth",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "earth"
+                ]
+              }
+            },
+            {
+              "title": "Eastern Vault",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "eastern_vault"
+                ]
+              }
+            },
+            {
+              "title": "Ruined Atoll",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "ruined_atoll"
+                ]
+              }
+            },
+            {
+              "title": "Frog's Domain",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "frogs_domain"
+                ]
+              }
+            },
+            {
+              "title": "The Grand Library",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "library"
+                ]
+              }
+            },
+            {
+              "title": "The Quarry",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "quarry"
+                ]
+              }
+            },
+            {
+              "title": "The Rooted Ziggurat",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "ziggurat"
+                ]
+              }
+            },
+            {
+              "title": "Swamp",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "graveyard"
+                ]
+              }
+            },
+            {
+              "title": "The Cathedral",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "cathedral"
+                ]
+              }
+            },
+            {
+              "title": "The Far Shore",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "far_shore"
+                ]
+              }
+            },
+            {
+              "title": "HOLY CROSS",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "secrets"
+                ]
+              }
+            }
+          ]
         }
+      ]
     }
+  }
 }

--- a/layouts/trackerpop_ladders_hints.json
+++ b/layouts/trackerpop_ladders_hints.json
@@ -1,83 +1,4 @@
 {
-  "settings_popup": {
-    "type": "array",
-    "margin": "5",
-    "content": [
-      {
-        "type": "group",
-        "header": "Glitch Mode",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "item",
-            "margin": "-5,-1,-5,-5",
-            "item": "mode"
-          }
-        ]
-      },
-      {
-        "type": "group",
-        "header": "Classic/Hexagon Quest",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "item",
-            "margin": "-5,-1,-5,-5",
-            "item": "hexagonquest"
-          }
-        ]
-      },
-      {
-        "type": "group",
-        "header": "Sword Setting",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "item",
-            "margin": "-5,-1,-5,-5",
-            "item": "progswordSetting"
-          }
-        ]
-      },
-      {
-        "type": "group",
-        "header": "Ladder Shuffle",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "item",
-            "margin": "-5,-1,-5,-5",
-            "item": "ladder_shuffle_off"
-          }
-        ]
-      },
-      {
-        "type": "group",
-        "header": "Pack Settings",
-        "header_background": "#3e4b57",
-        "content": [
-          {
-            "type": "array",
-            "orientation": "horizontal",
-            "content": [
-              {
-                "type": "item",
-                "max_width": 80,
-                "margin": "5,5,5,5",
-                "item": "auto_tab"
-              },
-              {
-                "type": "item",
-                "max_width": 80,
-                "margin": "5,5,5,5",
-                "item": "show_hints"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
   "tracker_horizontal": {
     "type": "container",
     "background": "#877373",
@@ -113,6 +34,36 @@
               "content": {
                 "type": "layout",
                 "key": "other"
+              }
+            },
+            {
+              "type": "group",
+              "header": "Ladders",
+              "margin": "0,0,0,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "ladders"
+              }
+            },
+            {
+              "type": "group",
+              "header": "Hints",
+              "margin": "0,0,3,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "hints"
+              }
+            },
+            {
+              "type": "group",
+              "header": "More Hints",
+              "margin": "0,0,3,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "hints2"
               }
             }
           ]

--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -217,7 +217,7 @@ function onClear(slot_data)
     if slot_data.shuffle_ladders then
         Tracker:FindObjectForCode("ladder_shuffle_off").CurrentStage = slot_data.shuffle_ladders
         -- needs to be called because onClear turns all the ladders off and the above line doesn't reenable them if shuffle_ladders is 0
-        ladderLayoutChange()
+        updateLayout()
     end
     
     -- manually run snes interface functions after onClear in case we are already ingame

--- a/scripts/logic_common.lua
+++ b/scripts/logic_common.lua
@@ -14,12 +14,11 @@ end
 
 ScriptHost:AddWatchForCode("useApLayout", "progswordSetting", apLayoutChange)
 
-function ladderLayoutChange()
+function updateLayout()
     local ladders = Tracker:FindObjectForCode("ladder_shuffle_off")
+    local layoutString = "layouts/trackerpop"
     if (string.find(Tracker.ActiveVariantUID, "standard") or string.find(Tracker.ActiveVariantUID, "var_itemsonly")) then
         if ladders.CurrentStage == 0 then
-            Tracker:AddLayouts("layouts/trackerpop.json")
-
             Tracker:FindObjectForCode("ladders_near_weathervane").Active = true
             Tracker:FindObjectForCode("ladders_near_overworld_checkpoint").Active = true
             Tracker:FindObjectForCode("ladders_near_patrol_cave").Active = true
@@ -42,7 +41,7 @@ function ladderLayoutChange()
             Tracker:FindObjectForCode("ladders_in_lower_quarry").Active = true
             Tracker:FindObjectForCode("ladders_in_swamp").Active = true
         else
-            Tracker:AddLayouts("layouts/trackerpop_ladders.json")
+            layoutString = layoutString .. "_ladders"
 
             Tracker:FindObjectForCode("ladders_near_weathervane").Active = false
             Tracker:FindObjectForCode("ladders_near_overworld_checkpoint").Active = false
@@ -66,9 +65,15 @@ function ladderLayoutChange()
             Tracker:FindObjectForCode("ladders_in_lower_quarry").Active = false
             Tracker:FindObjectForCode("ladders_in_swamp").Active = false
         end
+
+        if Tracker:FindObjectForCode("show_hints").Active then
+            layoutString = layoutString .. "_hints"
+        end
+
+        Tracker:AddLayouts(layoutString .. ".json")
     end
 
 end
 
-ScriptHost:AddWatchForCode("ladderLayoutOff", "ladder_shuffle_off", ladderLayoutChange)
-ScriptHost:AddWatchForCode("ladderLayoutOn", "ladder_shuffle_on", ladderLayoutChange)
+ScriptHost:AddWatchForCode("ladderLayout", "ladder_shuffle_off", updateLayout)
+ScriptHost:AddWatchForCode("hintsLayout", "show_hints", updateLayout)


### PR DESCRIPTION
**NOTE: Recommend viewing with whitespace changes hidden.**

- Format JSON consistently in a few files because the inconsistent whitespace was annoying to work with
- Add a setting to show the hint panels (off by default, shares hint icon):
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/073747d8-69c7-41db-bbb3-c4d701c9c791)
- Repurpose ladder layout code to adjust all layouts:
    - No hints or ladders (default):
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/a4ccbef2-87fe-45c8-8ccc-466745c1aa2d)
    - Ladders, no hints: 
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/f44e83c4-835f-4418-9eda-76c07e74c79f)
    - Hints, no ladders (previous default): 
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/b624effb-6cac-4b21-8896-5befd07ccb38)
    - Ladders and hints: 
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/3b53ba53-f602-4d5a-a7b6-a8ca5a9b21fe)

The `trackerpop(_ladders)?(_hints)?.json` files are mostly identical but change which panels are included. There may be a better way to do this with poptracker's layout references but this works fine and I spent a few unsuccessful minutes trying to get that to work.