### PR TITLE
Fix for ladders not loading from autosave properly, make weapon optional in well

### DIFF
--- a/locations/locations_pop_er.json
+++ b/locations/locations_pop_er.json
@@ -3284,21 +3284,21 @@
         "name": "Beneath the Well Front",
         "access_rules": [
           "@Beneath the Well Ladder Exit,ladders_in_well",
-          "@Beneath the Well Main,staff",
-          "@Beneath the Well Main,stick",
-          "@Beneath the Well Main,sword"
+          "@Beneath the Well Main,[staff]",
+          "@Beneath the Well Main,[stick]",
+          "@Beneath the Well Main,[sword]"
         ],
         "children": []
       },
       {
         "name": "Beneath the Well Main",
         "access_rules": [
-          "@Beneath the Well Back,ladders_in_well,staff",
-          "@Beneath the Well Back,ladders_in_well,stick",
-          "@Beneath the Well Back,ladders_in_well,sword",
-          "@Beneath the Well Front,staff",
-          "@Beneath the Well Front,stick",
-          "@Beneath the Well Front,sword"
+          "@Beneath the Well Back,ladders_in_well,[staff]",
+          "@Beneath the Well Back,ladders_in_well,[stick]",
+          "@Beneath the Well Back,ladders_in_well,[sword]",
+          "@Beneath the Well Front,[staff]",
+          "@Beneath the Well Front,[stick]",
+          "@Beneath the Well Front,[sword]"
         ],
         "children": [
           {

--- a/locations/locations_pop_er.json
+++ b/locations/locations_pop_er.json
@@ -6064,12 +6064,12 @@
       {
         "name": "Quarry",
         "access_rules": [
-          "@Quarry Back,staff",
-          "@Quarry Back,sword",
-          "@Quarry Entry,staff",
-          "@Quarry Entry,sword",
-          "@Quarry Monastery Entry,staff",
-          "@Quarry Monastery Entry,sword"
+          "@Quarry Back,[staff]",
+          "@Quarry Back,[sword]",
+          "@Quarry Entry,[staff]",
+          "@Quarry Entry,[sword]",
+          "@Quarry Monastery Entry,[staff]",
+          "@Quarry Monastery Entry,[sword]"
         ],
         "children": [
           {

--- a/scripts/logic_common.lua
+++ b/scripts/logic_common.lua
@@ -18,52 +18,15 @@ function updateLayout()
     local ladders = Tracker:FindObjectForCode("ladder_shuffle_off")
     local layoutString = "layouts/trackerpop"
     if (string.find(Tracker.ActiveVariantUID, "standard") or string.find(Tracker.ActiveVariantUID, "var_itemsonly")) then
-        if ladders.CurrentStage == 0 then
-            Tracker:FindObjectForCode("ladders_near_weathervane").Active = true
-            Tracker:FindObjectForCode("ladders_near_overworld_checkpoint").Active = true
-            Tracker:FindObjectForCode("ladders_near_patrol_cave").Active = true
-            Tracker:FindObjectForCode("ladder_near_temple_rafters").Active = true
-            Tracker:FindObjectForCode("ladders_near_dark_tomb").Active = true
-            Tracker:FindObjectForCode("ladder_to_quarry").Active = true
-            Tracker:FindObjectForCode("ladders_to_west_bell").Active = true
-            Tracker:FindObjectForCode("ladders_in_overworld_town").Active = true
-            Tracker:FindObjectForCode("ladder_to_ruined_atoll").Active = true
-            Tracker:FindObjectForCode("ladder_to_swamp").Active = true
-            Tracker:FindObjectForCode("ladders_in_well").Active = true
-            Tracker:FindObjectForCode("ladder_in_dark_tomb").Active = true
-            Tracker:FindObjectForCode("ladder_to_east_forest").Active = true
-            Tracker:FindObjectForCode("ladders_to_lower_forest").Active = true
-            Tracker:FindObjectForCode("ladder_to_beneath_the_vault").Active = true
-            Tracker:FindObjectForCode("ladders_in_hourglass_cave").Active = true
-            Tracker:FindObjectForCode("ladders_in_south_atoll").Active = true
-            Tracker:FindObjectForCode("ladders_to_frogs_domain").Active = true
-            Tracker:FindObjectForCode("ladders_in_library").Active = true
-            Tracker:FindObjectForCode("ladders_in_lower_quarry").Active = true
-            Tracker:FindObjectForCode("ladders_in_swamp").Active = true
-        else
+        local laddersEnabledState = true
+        if ladders.CurrentStage ~= 0 then
             layoutString = layoutString .. "_ladders"
+            laddersEnabledState = false
+        end
 
-            Tracker:FindObjectForCode("ladders_near_weathervane").Active = false
-            Tracker:FindObjectForCode("ladders_near_overworld_checkpoint").Active = false
-            Tracker:FindObjectForCode("ladders_near_patrol_cave").Active = false
-            Tracker:FindObjectForCode("ladder_near_temple_rafters").Active = false
-            Tracker:FindObjectForCode("ladders_near_dark_tomb").Active = false
-            Tracker:FindObjectForCode("ladder_to_quarry").Active = false
-            Tracker:FindObjectForCode("ladders_to_west_bell").Active = false
-            Tracker:FindObjectForCode("ladders_in_overworld_town").Active = false
-            Tracker:FindObjectForCode("ladder_to_ruined_atoll").Active = false
-            Tracker:FindObjectForCode("ladder_to_swamp").Active = false
-            Tracker:FindObjectForCode("ladders_in_well").Active = false
-            Tracker:FindObjectForCode("ladder_in_dark_tomb").Active = false
-            Tracker:FindObjectForCode("ladder_to_east_forest").Active = false
-            Tracker:FindObjectForCode("ladders_to_lower_forest").Active = false
-            Tracker:FindObjectForCode("ladder_to_beneath_the_vault").Active = false
-            Tracker:FindObjectForCode("ladders_in_hourglass_cave").Active = false
-            Tracker:FindObjectForCode("ladders_in_south_atoll").Active = false
-            Tracker:FindObjectForCode("ladders_to_frogs_domain").Active = false
-            Tracker:FindObjectForCode("ladders_in_library").Active = false
-            Tracker:FindObjectForCode("ladders_in_lower_quarry").Active = false
-            Tracker:FindObjectForCode("ladders_in_swamp").Active = false
+        -- need to skip if we're loading a state, as this overrides the loaded state
+        if not Tracker.BulkUpdate then
+            setAllLaddersState(laddersEnabledState)
         end
 
         if Tracker:FindObjectForCode("show_hints").Active then
@@ -73,6 +36,30 @@ function updateLayout()
         Tracker:AddLayouts(layoutString .. ".json")
     end
 
+end
+
+function setAllLaddersState(active)
+    Tracker:FindObjectForCode("ladders_near_weathervane").Active = active
+    Tracker:FindObjectForCode("ladders_near_overworld_checkpoint").Active = active
+    Tracker:FindObjectForCode("ladders_near_patrol_cave").Active = active
+    Tracker:FindObjectForCode("ladder_near_temple_rafters").Active = active
+    Tracker:FindObjectForCode("ladders_near_dark_tomb").Active = active
+    Tracker:FindObjectForCode("ladder_to_quarry").Active = active
+    Tracker:FindObjectForCode("ladders_to_west_bell").Active = active
+    Tracker:FindObjectForCode("ladders_in_overworld_town").Active = active
+    Tracker:FindObjectForCode("ladder_to_ruined_atoll").Active = active
+    Tracker:FindObjectForCode("ladder_to_swamp").Active = active
+    Tracker:FindObjectForCode("ladders_in_well").Active = active
+    Tracker:FindObjectForCode("ladder_in_dark_tomb").Active = active
+    Tracker:FindObjectForCode("ladder_to_east_forest").Active = active
+    Tracker:FindObjectForCode("ladders_to_lower_forest").Active = active
+    Tracker:FindObjectForCode("ladder_to_beneath_the_vault").Active = active
+    Tracker:FindObjectForCode("ladders_in_hourglass_cave").Active = active
+    Tracker:FindObjectForCode("ladders_in_south_atoll").Active = active
+    Tracker:FindObjectForCode("ladders_to_frogs_domain").Active = active
+    Tracker:FindObjectForCode("ladders_in_library").Active = active
+    Tracker:FindObjectForCode("ladders_in_lower_quarry").Active = active
+    Tracker:FindObjectForCode("ladders_in_swamp").Active = active
 end
 
 ScriptHost:AddWatchForCode("ladderLayout", "ladder_shuffle_off", updateLayout)


### PR DESCRIPTION
- Fixes a bug where loading state would not load the state of ladders correctly from autosave because the code watch would see the setting being toggled and clear the loaded state
- Makes a weapon optional in the well and quarry, since the checks are _doable_ but not recommended without a weapon