### PR TITLE
Make far shore->fortress portal one directional

### DIFF
--- a/locations/locations_pop_er.json
+++ b/locations/locations_pop_er.json
@@ -8142,7 +8142,6 @@
       {
         "name": "Far Shore to Fortress Region",
         "access_rules": [
-          "@Far Shore,pray",
           "@Fortress Arena Portal"
         ],
         "children": []


### PR DESCRIPTION
The interior of the eastern vault fortress is mistakenly being shown as accessible with only prayer (vault key added for clarity):
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/1479d097-6d6a-4ceb-a79f-e67b72a948ad)


This is because the tracker logic considers the interior of the vault accessible from the far shore without having activated the fuses outside (when porting the logic, events were handled manually and this was a mistake introduced there).

The simple fix is to make this portal one-directional (the same thing is done for the library and ziggurat portals). For tracker purposes (and for non-ER) this is correct enough.

After fix:
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/1f68e5f6-3662-455e-bfd1-76be2ba6b959)

(it is yellow because one could go through beneath the vault lanternless and light the fuses)