### PR TITLE
Add minimal layout

### DIFF
--- a/items/common_pop.json
+++ b/items/common_pop.json
@@ -282,7 +282,7 @@
 	},
 	//Collectibles
 	{
-		"name": "Souls",
+		"name": "Fairies",
 		"type": "consumable",
 		"loop": true,
 		"img":"images/souls.png",

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,12 @@
         "ap"
       ]
     },
+    "var_minimal": {
+      "display_name": "Minimal Map Tracker",
+      "flags": [
+        "ap"
+      ]
+    },
     "var_maponly": {
       "display_name": "Map Only Tracker",
       "flags": [

--- a/scripts/logic_common.lua
+++ b/scripts/logic_common.lua
@@ -1,7 +1,7 @@
 -- LAYOUT SWITCHING
 function apLayoutChange()
     local progSword = Tracker:FindObjectForCode("progswordSetting")
-    if (string.find(Tracker.ActiveVariantUID, "standard")) then
+    if (string.find(Tracker.ActiveVariantUID, "standard") or string.find(Tracker.ActiveVariantUID, "var_itemsonly") or string.find(Tracker.ActiveVariantUID, "var_minimal")) then
         if progSword.CurrentStage == 1 then
             Tracker:AddLayouts("layouts/itemspop_progsword.json")
             Tracker:AddLayouts("layouts/broadcastpop_progsword.json")
@@ -17,7 +17,7 @@ ScriptHost:AddWatchForCode("useApLayout", "progswordSetting", apLayoutChange)
 function updateLayout()
     local ladders = Tracker:FindObjectForCode("ladder_shuffle_off")
     local layoutString = "layouts/trackerpop"
-    if (string.find(Tracker.ActiveVariantUID, "standard") or string.find(Tracker.ActiveVariantUID, "var_itemsonly")) then
+    if (string.find(Tracker.ActiveVariantUID, "standard") or string.find(Tracker.ActiveVariantUID, "var_itemsonly") or string.find(Tracker.ActiveVariantUID, "var_minimal")) then
         local laddersEnabledState = true
         if ladders.CurrentStage ~= 0 then
             layoutString = layoutString .. "_ladders"

--- a/var_minimal/layouts/broadcastpop_progsword.json
+++ b/var_minimal/layouts/broadcastpop_progsword.json
@@ -1,0 +1,25 @@
+{
+  "tracker_broadcast": {
+    "type": "array",
+    "dropshadow": true,
+    "margin": "10",
+    "content": [
+      {
+        "type": "array",
+        "orientation": "vertical",
+        "content": [
+          {
+            "type": "itemgrid",
+            "h_alignment": "center",
+            "item_margin": "4,5",
+            "rows": [
+              ["progsword", "dagger", "staff", "orb", "gun", "dash", "light"],
+              ["mask", "pray", "cross", "icerod", "soul", "wishes", "oldkey"],
+              ["key", "vaultkey", "red", "green", "blue", "ding", "dong"]
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/var_minimal/layouts/items.json
+++ b/var_minimal/layouts/items.json
@@ -1,0 +1,85 @@
+{
+    "shared_item_grid": {
+        "type":"array",
+        "orientation": "horizontal",
+        "content": [
+            {
+                "type": "itemgrid",
+                "h_alignment": "left",
+                "item_margin": "1,2",
+				"item_size": 40,
+                "rows": [
+					["healshard", "heal", "red", "green", "blue", "oldkey", "key"],
+                    ["shield", "light", "dash", "vaultkey", "slot", "manual", "soul"],
+					["dynamite", "firebomb", "icebomb", "lure", "effigy", "wishes", "mask"],
+					["stick", "sword", "dagger", "icerod", "staff", "orb", "gun", "hourglass"],
+					["fangs", "idols", "powder", "flowers", "leaves", "shrooms","hexquest"],
+					["pray","cross","dath","goldenpower","justawell","ding", "dong", "visit"],
+					["captain", "gknight", "engine", "librarian", "scavboss", "gauntlet", "heir"]
+                ]
+            }
+		]
+    },
+	"other": {
+		"type":"array",
+        "orientation": "horizontal",
+        "content": [
+			{
+			"type": "itemgrid",
+				"h_alignment": "center",
+				"item_margin": "1,2",
+				"item_size": 40,
+				"rows": [
+					["anklet", "gem", "blueperil", "bone"],
+					["bracer", "strap", "firesword", "ash"],
+					["loud", "cup", "mecho", "bell"],
+					["orangeperil", "perfume", "mask", "tincture"],
+					["mayor", "tunic", "geometry", "vintage"],
+					["pals", "weasel", "spring", "powerup"],
+					["work", "phonomath", "dusty", "friend"]
+				]			
+			}
+		]
+	},
+	"hints": {
+		"type":"array",
+        "orientation": "horizontal",
+        "content": [
+			{
+			"type": "itemgrid",
+				"h_alignment": "center",
+				"item_margin": "1,2",
+				"item_size": 73,
+				"rows": [
+					["mailbox", "arrow", "mailhint", "blank", "dash", "isin", "laurelshint"],
+					["gravehexGL", "isin", "gravehintGL", "blank", "graveitemEF", "isin", "gravehintEF"],
+					["gravehexMQ", "isin", "gravehintMQ", "blank", "graveitemWG", "isin", "gravehintWG"],
+					["gravehexSW", "isin", "gravehintSW", "blank", "graveitemFF", "isin", "gravehintFF"]
+				]			
+			}
+		]
+	},
+    "tracker_capture_item": {
+        "type": "container",
+        "content": {
+            "type": "itemgrid",
+            "h_alignment": "center",
+            "item_margin": "1,2",
+            "rows": [
+                ["healshard", "heal", "red", "green", "blue", "oldkey", "key"],
+				["shield", "light", "dash", "vaultkey", "slot", "manual", "soul"],
+				["dynamite", "firebomb", "icebomb", "lure", "effigy", "wishes", "mask"],
+				["stick", "sword", "dagger", "staff", "orb", "gun", "hourglass"],
+				["fangs", "idols", "powder", "flowers", "leaves", "shrooms","hexquest"],
+				["anklet", "gem", "blueperil", "bone"],
+				["bracer", "strap", "firesword", "ash"],
+				["loud", "cup", "mecho", "bell"],
+				["orangeperil", "perfume", "mask", "tincture"],
+				["mayor", "tunic", "geometry", "vintage"],
+				["pals", "weasel", "spring", "powerup"],
+				["work", "phonomath", "dusty", "friend"],
+				["pray","cross","icerod","silver"]
+            ]
+        }
+    }
+}

--- a/var_minimal/layouts/itemspop.json
+++ b/var_minimal/layouts/itemspop.json
@@ -1,0 +1,62 @@
+{
+  "shared_item_grid": {
+    "type": "array",
+    "orientation": "horizontal",
+    "content": [
+      {
+        "type": "itemgrid",
+        "h_alignment": "center",
+        "margin": "-1,0,-5,0",
+        "item_margin": "1,2",
+        "item_size": 40,
+        "rows": [
+          ["stick", "sword", "dagger", "staff", "orb", "gun", "dash", "light"],
+          ["mask", "pray", "cross", "icerod", "soul", "wishes", "oldkey"],
+          ["key", "vaultkey", "red", "green", "blue", "ding", "dong"]
+        ]
+      }
+    ]
+  },
+  "ladders": {
+    "type": "array",
+    "orientation": "horizontal",
+    "content": [
+      {
+        "type": "itemgrid",
+        "h_alignment": "center",
+        "margin": "0,0,0,0",
+        "item_margin": "2,2",
+        "item_size": "40",
+        "rows": [
+          [
+            "ladders_near_weathervane",
+            "ladders_near_overworld_checkpoint",
+            "ladders_near_patrol_cave",
+            "ladder_near_temple_rafters",
+            "ladders_near_dark_tomb",
+            "ladder_in_dark_tomb",
+            "ladders_to_west_bell"
+          ],
+          [
+            "ladders_in_overworld_town",
+            "ladders_in_hourglass_cave",
+            "ladders_in_well",
+            "ladder_to_quarry",
+            "ladders_in_lower_quarry",
+            "ladder_to_east_forest",
+            "ladders_to_lower_forest"
+          ],
+          [
+            "ladder_to_beneath_the_vault",
+            "ladder_to_ruined_atoll",
+            "ladders_in_south_atoll",
+            "ladders_to_frogs_domain",
+            "ladders_in_library",
+            "ladder_to_swamp",
+            "ladders_in_swamp"
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/var_minimal/layouts/itemspop_progsword.json
+++ b/var_minimal/layouts/itemspop_progsword.json
@@ -1,0 +1,20 @@
+{
+  "shared_item_grid": {
+    "type": "array",
+    "orientation": "horizontal",
+    "content": [
+      {
+        "type": "itemgrid",
+        "h_alignment": "center",
+        "margin": "-1,0,-5,0",
+        "item_margin": "1,2",
+        "item_size": 40,
+        "rows": [
+          ["progsword", "dagger", "staff", "orb", "gun", "dash", "light"],
+          ["mask", "pray", "cross", "icerod", "soul", "wishes", "oldkey"],
+          ["key", "vaultkey", "red", "green", "blue", "ding", "dong"]
+        ]
+      }
+    ]
+  }
+}

--- a/var_minimal/layouts/standard_broadcast.json
+++ b/var_minimal/layouts/standard_broadcast.json
@@ -1,0 +1,25 @@
+{
+  "tracker_broadcast": {
+    "type": "array",
+    "dropshadow": true,
+    "margin": "10",
+    "content": [
+      {
+        "type": "array",
+        "orientation": "vertical",
+        "content": [
+          {
+            "type": "itemgrid",
+            "h_alignment": "center",
+            "item_margin": "4,5",
+            "rows": [
+              ["stick", "sword", "dagger", "staff", "orb", "gun", "dash", "light"],
+              ["mask", "pray", "cross", "icerod", "soul", "wishes", "oldkey"],
+              ["key", "vaultkey", "red", "green", "blue", "ding", "dong"]
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/var_minimal/layouts/standard_broadcastpop.json
+++ b/var_minimal/layouts/standard_broadcastpop.json
@@ -1,0 +1,25 @@
+{
+  "tracker_broadcast": {
+    "type": "array",
+    "dropshadow": true,
+    "margin": "10",
+    "content": [
+      {
+        "type": "array",
+        "orientation": "vertical",
+        "content": [
+          {
+            "type": "itemgrid",
+            "h_alignment": "center",
+            "item_margin": "4,5",
+            "rows": [
+              ["stick", "sword", "dagger", "staff", "orb", "gun", "dash", "light"],
+              ["mask", "pray", "cross", "icerod", "soul", "wishes", "oldkey"],
+              ["key", "vaultkey", "red", "green", "blue", "ding", "dong"]
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/var_minimal/layouts/tracker.json
+++ b/var_minimal/layouts/tracker.json
@@ -1,0 +1,376 @@
+{
+    "settings_popup": {
+        "type": "array",
+        "margin": "5",
+        "content": [
+            {
+                "type": "group",
+                "header": "Glitch Mode",
+                "header_background": "#3e4b57",
+                "content":[
+                    {
+                        "type": "item",
+                        "margin": "-5,-1,-5,-5",
+                        "item": "mode"
+                    }
+                ]
+            }            
+        ]
+    },    
+    "tracker_default": {
+        "type": "container",
+        "background": "#877373",
+        "content": {
+            "type": "dock",
+            "dropshadow": true,
+            "content": [
+                {
+                    "type": "dock",
+                    "dock": "left",
+                    "v_alignment": "stretch",
+                    "content": [
+                        {
+                            "type": "group",
+                            "header": "Items",
+                            "dock": "top",
+                            "header_content": {
+                                "type": "button_popup",
+                                "style": "settings",
+                                "popup_background": "#55212121",
+                                "layout": "settings_popup"
+                            },
+                            "content": {
+                                "type": "layout",
+                                "key": "shared_item_grid"
+                            }
+                        },
+                        {
+                            "type": "group",
+                            "header": "Pinned Locations",
+                            "content": {
+                                "type": "recentpins",
+                                "style": "wrap",
+                                "h_alignment": "stretch",
+                                "v_alignment": "stretch",
+                                "orientation": "vertical",
+                                "compact": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type":"tabbed",
+					"tabs": [
+						{							
+							"title": "Full Map",
+							"content": {
+								"type": "map",
+								"maps": ["fullmap"]
+							}
+						},
+						{							
+							"title": "Overworld",
+							"content": {
+								"type": "map",
+								"maps": ["overworld"]
+							}
+						},
+						{							
+							"title": "East Forest",
+							"content": {
+								"type": "map",
+								"maps": ["east_forest"]
+							}
+						},
+						{							
+							"title": "Beneath the Well",
+							"content": {
+								"type": "map",
+								"maps": ["well"]
+							}
+						},
+						{							
+							"title": "Dark Tomb",
+							"content": {
+								"type": "map",
+								"maps": ["dark_tomb"]
+							}
+						},
+						{							
+							"title": "West Gardens",
+							"content": {
+								"type": "map",
+								"maps": ["west_gardens"]
+							}
+						},
+						{							
+							"title": "Beneath the Earth",
+							"content": {
+								"type": "map",
+								"maps": ["earth"]
+							}
+						},
+						{							
+							"title": "Eastern Vault",
+							"content": {
+								"type": "map",
+								"maps": ["eastern_vault"]
+							}
+						},
+						{							
+							"title": "Ruined Atoll",
+							"content": {
+								"type": "map",
+								"maps": ["ruined_atoll"]
+							}
+						},
+						{							
+							"title": "Frog's Domain",
+							"content": {
+								"type": "map",
+								"maps": ["frogs_domain"]
+							}
+						},
+						{							
+							"title": "The Grand Library",
+							"content": {
+								"type": "map",
+								"maps": ["library"]
+							}
+						},
+						{							
+							"title": "The Quarry",
+							"content": {
+								"type": "map",
+								"maps": ["quarry"]
+							}
+						},
+						{							
+							"title": "The Rooted Ziggurat",
+							"content": {
+								"type": "map",
+								"maps": ["ziggurat"]
+							}
+						},
+						{							
+							"title": "Old Burying Ground",
+							"content": {
+								"type": "map",
+								"maps": ["graveyard"]
+							}
+						},
+						{							
+							"title": "The Cathedral",
+							"content": {
+								"type": "map",
+								"maps": ["cathedral"]
+							}
+						},
+						{							
+							"title": "The Far Shore",
+							"content": {
+								"type": "map",
+								"maps": ["far_shore"]
+							}
+						},
+						{							
+							"title": "HOLY CROSS",
+							"content": {
+								"type": "map",
+								"maps": ["secrets"]
+							}
+						}
+					]
+                }
+            ]
+        }
+    },
+    "tracker_horizontal": {
+        "type": "container",
+        "background": "#877373",
+        "content": {
+            "type": "dock",
+            "dropshadow": true,
+            "content": [
+                {
+                    "type": "dock",
+                    "dock": "bottom",
+                    "content": [
+                        {
+                            "type": "group",
+                            "header": "Items",
+                            "margin": "0,0,3,0",
+                            "dock": "left",
+                            "content": {
+                                "type": "layout",
+                                "key": "shared_item_grid"
+                            },
+                            "header_content": {
+                                "type": "button_popup",
+                                "style": "settings",
+                                "popup_background": "#55212121",
+                                "layout": "settings_popup"
+                            }
+                        },
+						{
+							"type": "group",
+                            "header": "Other Treasures",
+                            "margin": "0,0,3,0",
+                            "dock": "left",
+                            "content": {
+                                "type": "layout",
+                                "key": "other"
+                            }
+						},
+						{
+							"type": "group",
+                            "header": "Hints",
+                            "margin": "0,0,3,0",
+                            "dock": "left",
+                            "content": {
+                                "type": "layout",
+                                "key": "hints"
+                            }
+						},
+                        {
+                            "type": "group",
+                            "header": "Pinned Locations",
+                            "content": {
+                                "type": "recentpins",
+                                "style": "wrap",
+                                "h_alignment": "stretch",
+                                "v_alignment": "stretch",
+                                "orientation": "horizontal",
+                                "compact": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type":"tabbed",
+					"tabs": [
+						{							
+							"title": "Full Map",
+							"content": {
+								"type": "map",
+								"maps": ["fullmap"]
+							}
+						},
+						{							
+							"title": "Overworld",
+							"content": {
+								"type": "map",
+								"maps": ["overworld"]
+							}
+						},
+						{							
+							"title": "East Forest",
+							"content": {
+								"type": "map",
+								"maps": ["east_forest"]
+							}
+						},
+						{							
+							"title": "Beneath the Well",
+							"content": {
+								"type": "map",
+								"maps": ["well"]
+							}
+						},
+						{							
+							"title": "Dark Tomb",
+							"content": {
+								"type": "map",
+								"maps": ["dark_tomb"]
+							}
+						},
+						{							
+							"title": "West Gardens",
+							"content": {
+								"type": "map",
+								"maps": ["west_gardens"]
+							}
+						},
+						{							
+							"title": "Beneath the Earth",
+							"content": {
+								"type": "map",
+								"maps": ["earth"]
+							}
+						},
+						{							
+							"title": "Eastern Vault",
+							"content": {
+								"type": "map",
+								"maps": ["eastern_vault"]
+							}
+						},
+						{							
+							"title": "Ruined Atoll",
+							"content": {
+								"type": "map",
+								"maps": ["ruined_atoll"]
+							}
+						},
+						{							
+							"title": "Frog's Domain",
+							"content": {
+								"type": "map",
+								"maps": ["frogs_domain"]
+							}
+						},
+						{							
+							"title": "The Grand Library",
+							"content": {
+								"type": "map",
+								"maps": ["library"]
+							}
+						},
+						{							
+							"title": "The Quarry",
+							"content": {
+								"type": "map",
+								"maps": ["quarry"]
+							}
+						},
+						{							
+							"title": "The Rooted Ziggurat",
+							"content": {
+								"type": "map",
+								"maps": ["ziggurat"]
+							}
+						},
+						{							
+							"title": "Old Burying Ground",
+							"content": {
+								"type": "map",
+								"maps": ["graveyard"]
+							}
+						},
+						{							
+							"title": "The Cathedral",
+							"content": {
+								"type": "map",
+								"maps": ["cathedral"]
+							}
+						},
+						{							
+							"title": "The Far Shore",
+							"content": {
+								"type": "map",
+								"maps": ["far_shore"]
+							}
+						},
+						{							
+							"title": "HOLY CROSS",
+							"content": {
+								"type": "map",
+								"maps": ["secrets"]
+							}
+						}
+					]
+                }
+            ]
+        }
+    }
+}

--- a/var_minimal/layouts/trackerpop.json
+++ b/var_minimal/layouts/trackerpop.json
@@ -1,0 +1,257 @@
+{
+  "settings_popup": {
+    "type": "array",
+    "margin": "5",
+    "content": [
+      {
+        "type": "group",
+        "header": "Glitch Mode",
+        "header_background": "#3e4b57",
+        "content": [
+          {
+            "type": "item",
+            "margin": "-5,-1,-5,-5",
+            "item": "mode"
+          }
+        ]
+      },
+      {
+        "type": "group",
+        "header": "Classic/Hexagon Quest",
+        "header_background": "#3e4b57",
+        "content": [
+          {
+            "type": "item",
+            "margin": "-5,-1,-5,-5",
+            "item": "hexagonquest"
+          }
+        ]
+      },
+      {
+        "type": "group",
+        "header": "Sword Setting",
+        "header_background": "#3e4b57",
+        "content": [
+          {
+            "type": "item",
+            "margin": "-5,-1,-5,-5",
+            "item": "progswordSetting"
+          }
+        ]
+      },
+      {
+        "type": "group",
+        "header": "Ladder Shuffle",
+        "header_background": "#3e4b57",
+        "content": [
+          {
+            "type": "item",
+            "margin": "-5,-1,-5,-5",
+            "item": "ladder_shuffle_off"
+          }
+        ]
+      },
+      {
+        "type": "group",
+        "header": "Pack Settings",
+        "header_background": "#3e4b57",
+        "content": [
+          {
+            "type": "array",
+            "orientation": "horizontal",
+            "content": [
+              {
+                "type": "item",
+                "max_width": 80,
+                "margin": "5,5,5,5",
+                "item": "auto_tab"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "tracker_horizontal": {
+    "type": "container",
+    "background": "#877373",
+    "content": {
+      "type": "dock",
+      "dropshadow": true,
+      "content": [
+        {
+          "type": "dock",
+          "dock": "bottom",
+          "h_alignment": "center",
+          "content": [
+            {
+              "type": "group",
+              "header": "Items",
+              "margin": "0,0,3,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "shared_item_grid"
+              },
+              "header_content": {
+                "type": "button_popup",
+                "style": "settings",
+                "popup_background": "#55212121",
+                "layout": "settings_popup"
+              }
+            }
+          ]
+        },
+        {
+          "type": "tabbed",
+          "tabs": [
+            {
+              "title": "Overworld",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "overworld"
+                ]
+              }
+            },
+            {
+              "title": "East Forest",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "east_forest"
+                ]
+              }
+            },
+            {
+              "title": "Beneath the Well",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "well"
+                ]
+              }
+            },
+            {
+              "title": "Dark Tomb",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "dark_tomb"
+                ]
+              }
+            },
+            {
+              "title": "West Garden",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "west_gardens"
+                ]
+              }
+            },
+            {
+              "title": "Beneath the Earth",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "earth"
+                ]
+              }
+            },
+            {
+              "title": "Eastern Vault",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "eastern_vault"
+                ]
+              }
+            },
+            {
+              "title": "Ruined Atoll",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "ruined_atoll"
+                ]
+              }
+            },
+            {
+              "title": "Frog's Domain",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "frogs_domain"
+                ]
+              }
+            },
+            {
+              "title": "The Grand Library",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "library"
+                ]
+              }
+            },
+            {
+              "title": "The Quarry",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "quarry"
+                ]
+              }
+            },
+            {
+              "title": "The Rooted Ziggurat",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "ziggurat"
+                ]
+              }
+            },
+            {
+              "title": "Swamp",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "graveyard"
+                ]
+              }
+            },
+            {
+              "title": "The Cathedral",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "cathedral"
+                ]
+              }
+            },
+            {
+              "title": "The Far Shore",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "far_shore"
+                ]
+              }
+            },
+            {
+              "title": "HOLY CROSS",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "secrets"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/var_minimal/layouts/trackerpop_ladders.json
+++ b/var_minimal/layouts/trackerpop_ladders.json
@@ -1,0 +1,194 @@
+{
+  "tracker_horizontal": {
+    "type": "container",
+    "background": "#877373",
+    "content": {
+      "type": "dock",
+      "dropshadow": true,
+      "content": [
+        {
+          "type": "dock",
+          "dock": "bottom",
+          "content": [
+            {
+              "type": "group",
+              "header": "Items",
+              "margin": "0,0,3,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "shared_item_grid"
+              },
+              "header_content": {
+                "type": "button_popup",
+                "style": "settings",
+                "popup_background": "#55212121",
+                "layout": "settings_popup"
+              }
+            },
+            {
+              "type": "group",
+              "header": "Ladders",
+              "margin": "0,0,0,0",
+              "dock": "left",
+              "content": {
+                "type": "layout",
+                "key": "ladders"
+              }
+            }
+          ]
+        },
+        {
+          "type": "tabbed",
+          "margin":"0,0,5,5",
+          "tabs": [
+            {
+              "title": "Overworld",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "overworld"
+                ]
+              }
+            },
+            {
+              "title": "East Forest",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "east_forest"
+                ]
+              }
+            },
+            {
+              "title": "Beneath the Well",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "well"
+                ]
+              }
+            },
+            {
+              "title": "Dark Tomb",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "dark_tomb"
+                ]
+              }
+            },
+            {
+              "title": "West Garden",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "west_gardens"
+                ]
+              }
+            },
+            {
+              "title": "Beneath the Earth",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "earth"
+                ]
+              }
+            },
+            {
+              "title": "Eastern Vault",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "eastern_vault"
+                ]
+              }
+            },
+            {
+              "title": "Ruined Atoll",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "ruined_atoll"
+                ]
+              }
+            },
+            {
+              "title": "Frog's Domain",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "frogs_domain"
+                ]
+              }
+            },
+            {
+              "title": "The Grand Library",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "library"
+                ]
+              }
+            },
+            {
+              "title": "The Quarry",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "quarry"
+                ]
+              }
+            },
+            {
+              "title": "The Rooted Ziggurat",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "ziggurat"
+                ]
+              }
+            },
+            {
+              "title": "Swamp",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "graveyard"
+                ]
+              }
+            },
+            {
+              "title": "The Cathedral",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "cathedral"
+                ]
+              }
+            },
+            {
+              "title": "The Far Shore",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "far_shore"
+                ]
+              }
+            },
+            {
+              "title": "HOLY CROSS",
+              "content": {
+                "type": "map",
+                "maps": [
+                  "secrets"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- Rename the display for fairies (`Souls` -> `Fairies`)
   - Could also go with `F A I R I E S ?` to match in-manual text

Add new layout: minimal
- Designed to make better use of space for small window sizes
- Reduces items to 3x7 (or 3x7+1 for non-progressive swords)
- Reorients ladders to 3 rows of 7 instead of 3 columns
- Does not display hint blocks (and removes option to enable them)

Without ladders:
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/972e7cbb-8efd-4537-9a17-81916de8d9bf)

With ladders:
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/ea18dbf1-ccf8-4b0b-96ec-64765dc34617)

Progressive sword off:
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/08b67a74-0bc5-49f4-8c56-8a7c3a2ae059)

Broadcast view matches items view (progressive sword shown):
![image](https://github.com/SapphireSapphic/TunicTracker/assets/2702546/b3e9593b-ecd8-4432-8ef3-64bcdb023e50)
