### PR TITLE
Update quarry bomb wall logic

### DIFF
--- a/locations/locations_pop_er.json
+++ b/locations/locations_pop_er.json
@@ -6540,9 +6540,7 @@
             "sections": [
               {
                 "name": "Boomy",
-                "access_rules": [
-                  "[mask]"
-                ],
+                "access_rules": null,
                 "item_count": 1
               }
             ]


### PR DESCRIPTION
This access rule was removed from logic -- you no longer are expected to have mask to get here.