### PR TITLE
Update upper zig by bridge switch rule

### DIFF
--- a/locations/locations_pop_er.json
+++ b/locations/locations_pop_er.json
@@ -6938,7 +6938,7 @@
               {
                 "name": "You can shoot it",
                 "access_rules": [
-                  "staff",
+                  "staff,dash",
                   "sword"
                 ],
                 "item_count": 1


### PR DESCRIPTION
It got adjusted to require laurels + wand or sword, since you could technically get in here with just prayer + orb + wand then not be able to beat the admin fight, and so you'd get soft locked