### PR TITLE
Fix potion and hp being swapped in PopTracker

### DIFF
--- a/layouts/itemspop.json
+++ b/layouts/itemspop.json
@@ -14,7 +14,7 @@
                     ["shield", "light", "dash", "vaultkey", "slot", "manual", "soul"],
 					["dynamite", "firebomb", "icebomb", "lure", "effigy", "wishes", "mask"],
 					["stick", "sword", "dagger", "icerod", "staff", "orb", "gun", "hourglass"],
-					["attrelic", "defrelic", "hprelic", "potionrelic", "sprelic", "mprelic","hexquest"],
+					["attrelic", "defrelic", "potionrelic", "hprelic", "sprelic", "mprelic","hexquest"],
 					["pray","cross","dath","goldenpower","justawell","ding", "dong"],
 					["captain", "gknight", "engine", "librarian", "scavboss", "gauntlet", "heir"]
                 ]

--- a/layouts/itemspop_progsword.json
+++ b/layouts/itemspop_progsword.json
@@ -14,7 +14,7 @@
                     ["shield", "light", "dash", "vaultkey", "slot", "manual", "soul"],
 					["dynamite", "firebomb", "icebomb", "lure", "effigy", "wishes", "mask"],
 					["progsword", "dagger", "icerod", "staff", "orb", "gun", "hourglass"],
-					["attrelic", "defrelic", "hprelic", "potionrelic", "sprelic", "mprelic","hexquest"],
+					["attrelic", "defrelic", "potionrelic", "hprelic", "sprelic", "mprelic","hexquest"],
 					["pray","cross","dath","goldenpower","justawell","ding", "dong"],
 					["captain", "gknight", "engine", "librarian", "scavboss", "gauntlet", "heir"]
                 ]


### PR DESCRIPTION
Tested by opening in PopTracker and verifying that potion and hp show up in the correct locations