### PR TITLE
Move slime ice grapple to Lower Forest

### DIFF
--- a/locations/locations_pop_er.json
+++ b/locations/locations_pop_er.json
@@ -2648,7 +2648,7 @@
               }
             ]
           },
-					{
+          {
             "name": "Ice Rod Grapple Chest",
             "map_locations": [
               {

--- a/locations/locations_pop_er.json
+++ b/locations/locations_pop_er.json
@@ -2527,31 +2527,6 @@
             ]
           },
           {
-            "name": "Ice Rod Grapple Chest",
-            "map_locations": [
-              {
-                "map": "fullmap",
-                "x": 3760,
-                "y": 2985
-              },
-              {
-                "map": "east_forest",
-                "x": 1384,
-                "y": 1266,
-                "size": 35
-              }
-            ],
-            "sections": [
-              {
-                "name": "Freeze the Blob and ascend With Orb",
-                "access_rules": [
-                  "dagger,icerod,orb,staff"
-                ],
-                "item_count": 1
-              }
-            ]
-          },
-          {
             "name": "Bombable Wall",
             "map_locations": [
               {
@@ -2669,6 +2644,31 @@
               {
                 "name": "Beneath Spider Chest",
                 "access_rules": null,
+                "item_count": 1
+              }
+            ]
+          },
+					{
+            "name": "Ice Rod Grapple Chest",
+            "map_locations": [
+              {
+                "map": "fullmap",
+                "x": 3760,
+                "y": 2985
+              },
+              {
+                "map": "east_forest",
+                "x": 1384,
+                "y": 1266,
+                "size": 35
+              }
+            ],
+            "sections": [
+              {
+                "name": "Freeze the Blob and ascend With Orb",
+                "access_rules": [
+                  "dagger,icerod,orb,staff"
+                ],
                 "item_count": 1
               }
             ]


### PR DESCRIPTION
In the apworld, this change was already made. We want it to logically expect you to be in Lower Forest and grapple the slime from below instead of from above, since people don't like going to lower forest via the ice slime from above cause they keep thinking they got soft locked.