### PR TITLE
Fix Heir access rules

### DIFF
--- a/items/common_pop.json
+++ b/items/common_pop.json
@@ -358,7 +358,7 @@
 		"loop": true,
 		"img": "images/hex_gold.png",
 		"codes": "hexquest",
-		"max_quantity": 50
+		"max_quantity": 100
 	},
 	//Stats
 	{

--- a/locations/locations_pop_er.json
+++ b/locations/locations_pop_er.json
@@ -8473,7 +8473,8 @@
       {
         "name": "Spirit Arena Victory",
         "access_rules": [
-          "@Spirit Arena,blue,green,red"
+          "@Spirit Arena,blue,green,red,@Sealed Temple,attrelic,defrelic,potionrelic,hprelic,sprelic,mprelic,sword",
+          "@Spirit Arena,$is_hexquest_on,$has_hex_goal_amount"
         ],
         "children": [
           {

--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -151,11 +151,7 @@ function onClear(slot_data)
 
     Tracker:FindObjectForCode("hexagonquest").CurrentStage = slot_data.hexagon_quest
     if slot_data.hexagon_quest ~= 0 then
-        --print("slot_data['hexagon_quest']: " .. slot_data['hexagon_quest'])
-        -- this is something hacky to make it care about the heir access rules, should be replaced eventually
-        for _, color in ipairs({"red", "green", "blue"}) do
-            Tracker:FindObjectForCode(color).Active = true
-        end
+        HEXGOAL = slot_data["Hexagon Quest Goal"]
     end
 
     set_option("er_off", slot_data.entrance_rando, false)

--- a/scripts/logic_common.lua
+++ b/scripts/logic_common.lua
@@ -51,6 +51,17 @@ function has_mask()
     return Tracker:FindObjectForCode("mask").Active or Tracker:FindObjectForCode("maskless").Active
 end
 
+function has_hex_goal_amount()
+    if HEXGOAL ~= nil and HEXGOAL ~= 0 then
+        return Tracker:ProviderCountForCode("hexquest") >= HEXGOAL
+    end
+    return false
+end
+
+function is_hexquest_on()
+    return Tracker:FindObjectForCode("hexagonquest").CurrentStage == 1
+end
+
 
 ScriptHost:AddWatchForCode("ladderLayout", "ladder_shuffle_off", updateLayout)
 ScriptHost:AddWatchForCode("hintsLayout", "show_hints", updateLayout)


### PR DESCRIPTION
- In standard, Heir now requires access to the Temple, all the hero relics, and a sword (in addition to Spirit Arena access and the 3 colored hexes)
- Added Hex Quest-specific Heir access rules, requiring the goal hex amount and access to the Spirit Arena